### PR TITLE
Update Decode.pm

### DIFF
--- a/lib/CBOR/PP/Decode.pm
+++ b/lib/CBOR/PP/Decode.pm
@@ -347,7 +347,7 @@ sub decode {
                 return ( 5, unpack( 'x f>', $_ ) );
             }
             elsif ($byte1 == 0xfb) {
-                return ( 5, unpack( 'x d>', $_ ) );
+                return ( 9, unpack( 'x d>', $_ ) );
             }
 
             die sprintf('can’t decode special value: %v.02x', $_);


### PR DESCRIPTION
Floating double precision is 8 bytes not 4 (+1 for lead in)

May well be a change needed to test harness as well.